### PR TITLE
VG-1286 Detect & display third-party cookies disabled error

### DIFF
--- a/src/components/CookiesBlocked.tsx
+++ b/src/components/CookiesBlocked.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import styled from "styled-components";
+
+const CookiesBlockedContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+
+  > * + * {
+    margin-top: 24px;
+  }
+`;
+
+const CookiesBlocked = () => (
+  <CookiesBlockedContainer>
+    <strong>{"Third-party cookies are disabled"}</strong>
+    <div>
+      {
+        "Please enable third-party cookies in order to make DApps properly works."
+      }
+    </div>
+  </CookiesBlockedContainer>
+);
+
+export default CookiesBlocked;


### PR DESCRIPTION
This PR makes `localStorage` accesses catch a specific `DOMException` that is caused by host browser forbidding third-party cookies, and send a specific message to host in this case.

Hope this is not too hacky and can be merged, so it would prevent us from using alternatives (like [third-party-cookie-check](https://github.com/boblauer/third-party-cookie-check)) that would require an additional iframe/domain to be loaded.

![cookies](https://user-images.githubusercontent.com/315259/134321028-c5ee8dc0-7af6-4a76-bf3c-2d46fbce59c0.gif)
